### PR TITLE
Copilot/fix failing docker unit job

### DIFF
--- a/__tests__/components/StatCard.vue.test.ts
+++ b/__tests__/components/StatCard.vue.test.ts
@@ -62,14 +62,14 @@ describe('StatCard.vue', () => {
     const wrapper: VueWrapper = mount(StatCard, {
       props: { ...baseProps, footnote: 'Fonte: IBGE' },
     });
-    const footnote = wrapper.find('p.text-[11px]');
+    const footnote = wrapper.find('[data-testid="statcard-footnote"]');
     expect(footnote.exists()).toBe(true);
     expect(footnote.text()).toBe('Fonte: IBGE');
   });
 
   it('does not render footnote when not provided', () => {
     const wrapper: VueWrapper = mount(StatCard, { props: baseProps });
-    expect(wrapper.find('p.text-[11px]').exists()).toBe(false);
+    expect(wrapper.find('[data-testid="statcard-footnote"]').exists()).toBe(false);
   });
 
   it('renders correctly with all optional props and slots', () => {
@@ -84,7 +84,7 @@ describe('StatCard.vue', () => {
     expect(wrapper.find('.badge-slot').text()).toBe('VIP');
     expect(wrapper.find('.value-slot').text()).toBe('1000');
     expect(wrapper.find('.chart-slot').text()).toBe('C');
-    expect(wrapper.find('p.text-[11px]').text()).toBe('Obs.');
+    expect(wrapper.find('[data-testid="statcard-footnote"]').text()).toBe('Obs.');
   });
 
   it('applies correct classes to root and header elements', () => {
@@ -100,7 +100,7 @@ describe('StatCard.vue', () => {
     const wrapper: VueWrapper = mount(StatCard, {
       props: { icon: 'bi-star', category: 'Cat', title: 'T' },
     });
-    expect(wrapper.find('p.text-[11px]').exists()).toBe(false);
+    expect(wrapper.find('[data-testid="statcard-footnote"]').exists()).toBe(false);
     expect(wrapper.findAll('.animate-pulse').length).toBe(0);
   });
 });

--- a/__tests__/composables/useIBGECityStats.test.ts
+++ b/__tests__/composables/useIBGECityStats.test.ts
@@ -3,9 +3,9 @@
  */
 import { nextTick } from 'vue';
 import { useIBGECityStats } from '../../src/composables/useIBGECityStats';
-import type { CityStats } from '../../src/services/IBGECityStatsService.js';
+import type { CityStats } from '../../src/services/IBGECityStatsService';
 
-jest.mock('../../src/services/IBGECityStatsService.js', () => ({
+jest.mock('../../src/services/IBGECityStatsService', () => ({
   fetchStats: jest.fn(),
 }));
 
@@ -28,7 +28,7 @@ jest.mock('../../src/data/AddressCache.js', () => {
   };
 });
 
-import { fetchStats } from '../../src/services/IBGECityStatsService.js';
+import { fetchStats } from '../../src/services/IBGECityStatsService';
 import AddressCache from '../../src/data/AddressCache.js';
 
 describe('useIBGECityStats', () => {

--- a/src/components/StatCard.vue
+++ b/src/components/StatCard.vue
@@ -39,7 +39,11 @@ defineProps<{
     <!-- Optional chart slot -->
     <slot name="chart" />
 
-    <p v-if="footnote" class="text-[11px] text-outline mt-4 font-medium leading-relaxed">
+    <p
+      v-if="footnote"
+      data-testid="statcard-footnote"
+      class="text-[11px] text-outline mt-4 font-medium leading-relaxed"
+    >
       {{ footnote }}
     </p>
   </div>


### PR DESCRIPTION
## Summary by Sourcery

Add a test ID to the StatCard footnote and update StatCard unit tests to target it instead of styling-based selectors.

Bug Fixes:
- Stabilize StatCard footnote tests by querying via a data-testid attribute instead of CSS class selectors.

Enhancements:
- Expose a dedicated data-testid attribute on the StatCard footnote element to support more robust testing.